### PR TITLE
fix: Resolved GPU Parallelization Problem

### DIFF
--- a/sc_api/aws/locals.tf
+++ b/sc_api/aws/locals.tf
@@ -224,6 +224,7 @@ locals {
           --gpus all -p 8000:8000 \
           -v /data:/app/storage \
           -v /data:/app/data \
+          -v /dev/shm/:/dev/shm \
           --log-driver=awslogs \
           --log-opt awslogs-region=${var.region} \
           --log-opt awslogs-group=${local.log_group_name} \


### PR DESCRIPTION
# GPU Shared Memory Optimization for API Containers

## What This Solves

The API containers running machine learning models on GPU instances were experiencing performance bottlenecks during parallel operations.

## What Changed

- Added a volume mount for `/dev/shm` from the host to the container
- This mount ensures the container has access to the host's shared memory allocation
- Enables more efficient inter-process communication for GPU operations
- Improves performance for multi-worker data loading pipelines
- No configuration changes needed on the application side

## Technical Details - How

The change was implemented in the Terraform configuration (`sc_api/aws/locals.tf`), specifically in the Docker run command:

```hcl
docker run -d --name ${var.container_name} \
  ...
  -v /dev/shm/:/dev/shm \
  ...
```

## Test

![image](https://github.com/user-attachments/assets/523df29a-3824-41c0-ad3b-2d318c452fe9)
